### PR TITLE
[WIP] Show history as matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Make rails console output pretty
   gem 'hirb'
+  gem 'byebug'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     arel (7.1.4)
     bindex (0.5.0)
     builder (3.2.3)
+    byebug (9.1.0)
     capybara (2.15.4)
       addressable
       mini_mime (>= 0.1.3)
@@ -215,6 +216,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   capybara
   coffee-rails (~> 4.2)
   hirb

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -20,20 +20,18 @@ class TeamsController < ApplicationController
   end
 
   def show
-    @todays_pairs = todays_pairs
     @new_person = TeamMember.new(team_id: team_id)
   end
 
-  def show_history
-    @number_of_times_paired_by_name = number_of_times_paired_by_name
-  end
 
   private
 
+  helper_method :todays_pairs
   def todays_pairs
     TodaysPairs.new(team: team).pairs
   end
 
+  helper_method :number_of_times_paired_by_name
   def number_of_times_paired_by_name
     PairHistory.number_of_times_paired_by_name(team.team_members.pluck(:id))
   end
@@ -64,6 +62,7 @@ class TeamsController < ApplicationController
     OverrideOptions.new(team, person).options
   end
 
+  helper_method :team
   def team
     @team ||= Team.find(team_id)
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -23,9 +23,18 @@ class TeamsController < ApplicationController
     @new_person = TeamMember.new(team_id: team_id)
   end
 
-
   private
 
+  helper_method :team
+  def team
+    @team ||= Team.find(team_id)
+  end
+
+  helper_method :team_members
+  def team_members
+    @team_members ||= team.members_including_statuses
+  end
+  
   helper_method :todays_pairs
   def todays_pairs
     TodaysPairs.new(team: team).pairs
@@ -34,6 +43,11 @@ class TeamsController < ApplicationController
   helper_method :number_of_times_paired_by_name
   def number_of_times_paired_by_name
     PairHistory.number_of_times_paired_by_name(team.team_members.pluck(:id))
+  end
+
+  helper_method :pair_history_per_person
+  def pair_history_per_person
+    PairHistory.pair_history_per_person(team)
   end
 
   def send_email(pairs)
@@ -60,11 +74,6 @@ class TeamsController < ApplicationController
 
   def overrides_for(person)
     OverrideOptions.new(team, person).options
-  end
-
-  helper_method :team
-  def team
-    @team ||= Team.find(team_id)
   end
 
   def team_id

--- a/app/models/pair_history.rb
+++ b/app/models/pair_history.rb
@@ -51,6 +51,20 @@ class PairHistory < ApplicationRecord
     end
   end
 
+  def self.pair_history_per_person(team)
+    ids = team.team_members.pluck(:id)
+    ungrouped_pairs = number_of_times_paired_by_name(ids)
+    members =  team.members_including_statuses.pluck(:name)
+
+    pairs_by_person = Hash[members.map {|x| [x, Hash[members.map {|x| [x, 0] }]] }]
+
+    ungrouped_pairs.each_pair do |(person, pair), count|
+      pairs_by_person[person][pair] = count
+    end
+
+    pairs_by_person
+  end
+
   private
 
   def self.named_results(raw_sql_query)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,7 @@
 class Team < ApplicationRecord
   has_many :team_members, -> { where(archived: false) }
+
+  def members_including_statuses
+    team_members + [TeamMember.solo, TeamMember.out_of_office]
+  end
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,15 +1,15 @@
 <%= render 'shared/i_in_pear' %>
 <div style='position: relative; width: 50%'>
-  <h2 style='display: inline-block'><%= @team.name %></h2>
+  <h2 style='display: inline-block'><%= team.name %></h2>
   <div style='bottom: 10px; right: 0; position: absolute'>
-    <a href="/teams/<%=@team.id%>/show_history">See Pair History</a>
+    <a href="/teams/<%=team.id%>/show_history">See Pair History</a>
   </div>
 </div>
 
-<% if @todays_pairs.any? %>
+<% if todays_pairs.any? %>
   <hr style='width: 50%; display: inline-block' />
   <h3>Today's Pairs</h3>
-  <% @todays_pairs.each do |pair| %>
+  <% todays_pairs.each do |pair| %>
       <%= pair.first.name %>
       - paired with -
       <%= pair.last.name %>
@@ -20,19 +20,19 @@
   <h3>Update Pairs</h3>
 <% end %>
 
-<%= form_tag(team_pairs_path(@team)) do %>
+<%= form_tag(team_pairs_path(team)) do %>
   <table class='table' style='width: 50%'>
     <tr>
       <th><h4>Team member</h4></th>
       <th><h4>Manually pair with</h4></th>
       <th><h4>Archive</h4></th>
     </tr>
-      <% @team.team_members.each do |person| %>
+      <% team.team_members.each do |person| %>
         <tr>
           <td><%= person.name %></td>
           <td><%= select_tag("[overrides]#{person.id}",  options_from_collection_for_select(overrides_for(person), :option_value, :display_text)) %></td>
           <td><%= link_to '<i class="fa fa-ban fa-fw"></i>'.html_safe,
-                          "/teams/#{@team.id}/members/#{person.id}",
+                          "/teams/#{team.id}/members/#{person.id}",
                           data: { confirm: "You sure you want to archive #{person.name}?",
                                   method: 'delete' } %>
           </td>
@@ -50,7 +50,7 @@
 <br /><br />
 
 <h3>Add Team Member</h3>
-<%= form_for @new_person, url: team_members_path(team_id: @team.id) do |f| %>
+<%= form_for @new_person, url: team_members_path(team_id: team.id) do |f| %>
   <%= f.text_field :name, class: 'form-control create-team-btn', placeholder: 'Name' %>
   <%= f.submit :Submit, class: 'btn btn-secondary' %>
 <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -7,21 +7,26 @@
 </div>
 
 <% if todays_pairs.any? %>
-  <hr style='width: 50%; display: inline-block' />
   <h3>Today's Pairs</h3>
-  <% todays_pairs.each do |pair| %>
-      <%= pair.first.name %>
-      - paired with -
-      <%= pair.last.name %>
-      <br />
-  <% end %>
-  <hr style='width: 50%; display: inline-block' />
+    <table class="table" style='width: 50%'>
+      <tbody>
+        <% todays_pairs.each do |pair| %>
+          <tr>
+            <td><%= pair.first.name %></td>
+            <td><i class="fa fa-arrow-right"></i></td>
+            <td><%= pair.last.name %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <br />
+    <br />
 
-  <h3>Update Pairs</h3>
+    <h3>Update Pairs</h3>
 <% end %>
 
 <%= form_tag(team_pairs_path(team)) do %>
-  <table class='table' style='width: 50%'>
+  <table class='table'>
     <tr>
       <th><h4>Team member</h4></th>
       <th><h4>Manually pair with</h4></th>

--- a/app/views/teams/show_history.html.erb
+++ b/app/views/teams/show_history.html.erb
@@ -1,4 +1,21 @@
-<% number_of_times_paired_by_name.each_pair do |(person1, person2), count| %>
-    <%= person1 %> paired with <%= person2 %> - <%= count %>x
-  <br />
-<% end %>
+<h2>Pair History for <%= team.name %></h2>
+<table class="table table-striped table-sm table-hover">
+  <thead>
+    <tr>
+      <th></th>
+      <% team_members.each do |member| %>
+          <th><%= member.name %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% pair_history_per_person.each_pair do |person, pairs| %>
+      <tr>
+        <td><%= person %></td>
+        <% pairs.each_pair do |pair, count| %>
+          <td><%= count %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/teams/show_history.html.erb
+++ b/app/views/teams/show_history.html.erb
@@ -1,4 +1,4 @@
-<% @number_of_times_paired_by_name.each_pair do |(person1, person2), count| %>
+<% number_of_times_paired_by_name.each_pair do |(person1, person2), count| %>
     <%= person1 %> paired with <%= person2 %> - <%= count %>x
   <br />
 <% end %>

--- a/app/views/teams/show_history.html.erb
+++ b/app/views/teams/show_history.html.erb
@@ -13,7 +13,13 @@
       <tr>
         <td><%= person %></td>
         <% pairs.each_pair do |pair, count| %>
-          <td><%= count %></td>
+          <td>
+            <% if count > 0 %>
+              <strong><%= count %></strong>
+            <% else %>
+              <small>x</small>
+            <% end %>
+          </td>
         <% end %>
       </tr>
     <% end %>


### PR DESCRIPTION
Work toward #4 -- these changes add a matrix view of pairing history:

![image](https://user-images.githubusercontent.com/3732709/33852806-d35f04f4-de89-11e7-9a1c-d2f778dc8df7.png)

This can be merged as is if you're just done looking at:
<img src="https://user-images.githubusercontent.com/3732709/33852981-581050ea-de8a-11e7-8b30-c010440e33ae.png" width="500" />

😁 But it's pretty gross and I'd like to fix it:
- [ ] Refactor `PairHistory#pair_history_per_person` to make better use of the database directly (rather than manipulating the results from `number_of_times_paired_by_name`
- [ ] Build the array for populating the history table in some kind of View Object or Decorator or somesuch. Then we can have fancy conditional classes (e.g., red when people have paired less than the average, etc.) without polluting the view.
